### PR TITLE
ci: fix duplicate CI runs on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,15 @@ name: Continuous Integration
 on:
   pull_request:
   push:
+    branches:
+      - main
     paths-ignore:
       - .github/**
       - README.md
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Restrict the push trigger in ci.yml to the main branch so feature-branch pushes are only handled by the pull_request event, and add a concurrency group to cancel stale runs for the same PR or branch. No job definitions were changed.